### PR TITLE
Fix deprecation warnings for `SublimeLinter`

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -22,7 +22,6 @@ class Sass(NodeLinter):
     cmd = ('sass-lint', '--verbose', '--no-exit', '--format', 'stylish')
     config_file = ('--config', '.sass-lint.yml', '~')
     npm_name = 'sass-lint'
-    syntax = ('css', 'sass', 'scss', 'vue')
     regex = (
         r'^\s+(?P<line>\d+):(?P<col>\d+)'
         r'\s+((?P<error>error)|(?P<warning>warning))'
@@ -44,8 +43,8 @@ class Sass(NodeLinter):
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 1.2.0'
-    selectors = {
-        'vue': 'source.sass.embedded.html'
+    defaults = {
+        'selector': 'source.sass'
     }
 
     def find_errors(self, output):


### PR DESCRIPTION
With the latest version of `Sublime Linter` (`4.12.0`), what were
deprecation warnings are now resulting in
`SublimeLinter-contrib-sass-lint` being unable to run.

This commit resolves those deprecation warnings, and returns
`SublimeLinter-contrib-sass-lint` to working order as of `SublimeLinter`
version `4.12.0`.