### PR TITLE
Remove ignored settings.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,12 +16,10 @@ from SublimeLinter.lint import NodeLinter
 
 
 class Sass(NodeLinter):
-
     """Provides an interface to the sass-lint executable."""
 
     cmd = ('sass-lint', '--verbose', '--no-exit', '--format', 'stylish')
     config_file = ('--config', '.sass-lint.yml', '~')
-    npm_name = 'sass-lint'
     regex = (
         r'^\s+(?P<line>\d+):(?P<col>\d+)'
         r'\s+((?P<error>error)|(?P<warning>warning))'
@@ -40,9 +38,6 @@ class Sass(NodeLinter):
         'scss': 'scss',
         'sass': 'sass'
     }
-    version_args = '--version'
-    version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 1.2.0'
     defaults = {
         'selector': 'source.sass'
     }

--- a/linter.py
+++ b/linter.py
@@ -22,7 +22,6 @@ class Sass(NodeLinter):
     cmd = ('sass-lint', '--verbose', '--no-exit', '--format', 'stylish')
     config_file = ('--config', '.sass-lint.yml', '~')
     npm_name = 'sass-lint'
-    syntax = ('css', 'sass', 'scss', 'vue')
     regex = (
         r'^\s+(?P<line>\d+):(?P<col>\d+)'
         r'\s+((?P<error>error)|(?P<warning>warning))'
@@ -44,8 +43,8 @@ class Sass(NodeLinter):
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
     version_requirement = '>= 1.2.0'
-    selectors = {
-        'vue': 'source.sass.embedded.html'
+    defaults = {
+        'selector': 'source.sass'
     }
 
     def find_errors(self, output):


### PR DESCRIPTION
There were a couple more settings that SublimeLinter warned about to cleanup:

> sass: Defining 'cls.version_args' has no effect. Please cleanup and remove these settings.
sass: Defining 'cls.version_re' has no effect. Please cleanup and remove these settings.
sass: Defining 'cls.version_requirement' has no effect. Please cleanup and remove these settings.
sass: Defining 'cls.npm_name' has no effect. Please cleanup and remove these settings.
